### PR TITLE
Add grok models and duplicate some

### DIFF
--- a/workers.js
+++ b/workers.js
@@ -1,18 +1,9 @@
 const API_KEY = "ahamaibyprakash25";
 
 const exposedToInternalMap = {
-  "claude-3-5-sonnet": "anthropic/claude-3-5-sonnet",
-  "claude-3-7-sonnet": "anthropic/claude-3-7-sonnet",
-  "claude-sonnet-4": "anthropic/claude-sonnet-4",
   "claude-3-5-sonnet-ashlynn": "ashlynn/claude-3-5-sonnet",
   "claude-sonnet-4-rproxy": "rproxy/claude-sonnet-4",
   "claude-opus-4": "rproxy/claude-opus-4",
-  "Kimi-K2": "Kimi-K2",
-  "DeepSeek-R1-Think": "DeepSeek-R1-Think",
-  "DeepSeek-R1-0528-Think": "DeepSeek-R1-0528-Think",
-  "DeepSeek-V3": "DeepSeek-V3",
-  "Llama4-Maverick-17B-lnstruct": "Llama4-Maverick-17B-lnstruct",
-  "Llama4-Scout-17B-16E-lnstruct": "Llama4-Scout-17B-16E-lnstruct",
   "grok-3-mini-beta": "HeckAI/x-ai/grok-3-mini-beta",
   "grok-3-mini-fast": "SciraChat/grok-3-mini-fast",
   "grok-3-mini": "SciraChat/grok-3-mini",
@@ -24,18 +15,9 @@ const exposedToInternalMap = {
 };
 
 const modelRoutes = {
-  "anthropic/claude-3-5-sonnet": "http://V1.s1.sdk.li/v1/chat/completions",
-  "anthropic/claude-3-7-sonnet": "http://V1.s1.sdk.li/v1/chat/completions",
-  "anthropic/claude-sonnet-4": "http://V1.s1.sdk.li/v1/chat/completions",
   "ashlynn/claude-3-5-sonnet": "https://ai.ashlynn.workers.dev/ask",
   "rproxy/claude-sonnet-4": "https://rproxy-nine.vercel.app/v1/chat/completions",
   "rproxy/claude-opus-4": "https://rproxy-nine.vercel.app/v1/chat/completions",
-  "Kimi-K2": "https://a7-at41rv.vercel.app/v1/chat/completions",
-  "DeepSeek-R1-Think": "https://a7-at41rv.vercel.app/v1/chat/completions",
-  "DeepSeek-R1-0528-Think": "https://a7-at41rv.vercel.app/v1/chat/completions",
-  "DeepSeek-V3": "https://a7-at41rv.vercel.app/v1/chat/completions",
-  "Llama4-Maverick-17B-lnstruct": "https://a7-at41rv.vercel.app/v1/chat/completions",
-  "Llama4-Scout-17B-16E-lnstruct": "https://a7-at41rv.vercel.app/v1/chat/completions",
   "HeckAI/x-ai/grok-3-mini-beta": "https://ai4free-test.hf.space/v1/chat/completions",
   "SciraChat/grok-3-mini-fast": "https://ai4free-test.hf.space/v1/chat/completions",
   "SciraChat/grok-3-mini": "https://ai4free-test.hf.space/v1/chat/completions",

--- a/workers.js
+++ b/workers.js
@@ -14,21 +14,13 @@ const exposedToInternalMap = {
   "Llama4-Maverick-17B-lnstruct": "Llama4-Maverick-17B-lnstruct",
   "Llama4-Scout-17B-16E-lnstruct": "Llama4-Scout-17B-16E-lnstruct",
   "grok-3-mini-beta": "HeckAI/x-ai/grok-3-mini-beta",
-  "grok-3-mini-beta-server-2": "HeckAI/x-ai/grok-3-mini-beta",
   "grok-3-mini-fast": "SciraChat/grok-3-mini-fast",
-  "grok-3-mini-fast-server-2": "SciraChat/grok-3-mini-fast",
   "grok-3-mini": "SciraChat/grok-3-mini",
-  "grok-3-mini-server-2": "SciraChat/grok-3-mini",
-  "grok-3-mini-flowith": "Flowith/grok-3-mini",
-  "grok-3-mini-flowith-server-2": "Flowith/grok-3-mini",
+  "grok-3-mini-server-2": "Flowith/grok-3-mini",
   "grok-3-fast": "SciraChat/grok-3-fast",
-  "grok-3-fast-server-2": "SciraChat/grok-3-fast",
   "grok-3-beta": "oivscode/grok-3-beta",
-  "grok-3-beta-server-2": "oivscode/grok-3-beta",
-  "grok-3-beta-toolbaz": "Toolbaz/grok-3-beta",
-  "grok-3-beta-toolbaz-server-2": "Toolbaz/grok-3-beta",
-  "grok-3-blackbox": "BLACKBOXAI/Grok 3",
-  "grok-3-blackbox-server-2": "BLACKBOXAI/Grok 3"
+  "grok-3-beta-server-2": "Toolbaz/grok-3-beta",
+  "grok-3-blackbox": "BLACKBOXAI/Grok 3"
 };
 
 const modelRoutes = {

--- a/workers.js
+++ b/workers.js
@@ -12,7 +12,23 @@ const exposedToInternalMap = {
   "DeepSeek-R1-0528-Think": "DeepSeek-R1-0528-Think",
   "DeepSeek-V3": "DeepSeek-V3",
   "Llama4-Maverick-17B-lnstruct": "Llama4-Maverick-17B-lnstruct",
-  "Llama4-Scout-17B-16E-lnstruct": "Llama4-Scout-17B-16E-lnstruct"
+  "Llama4-Scout-17B-16E-lnstruct": "Llama4-Scout-17B-16E-lnstruct",
+  "grok-3-mini-beta": "HeckAI/x-ai/grok-3-mini-beta",
+  "grok-3-mini-beta-server-2": "HeckAI/x-ai/grok-3-mini-beta",
+  "grok-3-mini-fast": "SciraChat/grok-3-mini-fast",
+  "grok-3-mini-fast-server-2": "SciraChat/grok-3-mini-fast",
+  "grok-3-mini": "SciraChat/grok-3-mini",
+  "grok-3-mini-server-2": "SciraChat/grok-3-mini",
+  "grok-3-mini-flowith": "Flowith/grok-3-mini",
+  "grok-3-mini-flowith-server-2": "Flowith/grok-3-mini",
+  "grok-3-fast": "SciraChat/grok-3-fast",
+  "grok-3-fast-server-2": "SciraChat/grok-3-fast",
+  "grok-3-beta": "oivscode/grok-3-beta",
+  "grok-3-beta-server-2": "oivscode/grok-3-beta",
+  "grok-3-beta-toolbaz": "Toolbaz/grok-3-beta",
+  "grok-3-beta-toolbaz-server-2": "Toolbaz/grok-3-beta",
+  "grok-3-blackbox": "BLACKBOXAI/Grok 3",
+  "grok-3-blackbox-server-2": "BLACKBOXAI/Grok 3"
 };
 
 const modelRoutes = {
@@ -27,7 +43,15 @@ const modelRoutes = {
   "DeepSeek-R1-0528-Think": "https://a7-at41rv.vercel.app/v1/chat/completions",
   "DeepSeek-V3": "https://a7-at41rv.vercel.app/v1/chat/completions",
   "Llama4-Maverick-17B-lnstruct": "https://a7-at41rv.vercel.app/v1/chat/completions",
-  "Llama4-Scout-17B-16E-lnstruct": "https://a7-at41rv.vercel.app/v1/chat/completions"
+  "Llama4-Scout-17B-16E-lnstruct": "https://a7-at41rv.vercel.app/v1/chat/completions",
+  "HeckAI/x-ai/grok-3-mini-beta": "https://ai4free-test.hf.space/v1/chat/completions",
+  "SciraChat/grok-3-mini-fast": "https://ai4free-test.hf.space/v1/chat/completions",
+  "SciraChat/grok-3-mini": "https://ai4free-test.hf.space/v1/chat/completions",
+  "Flowith/grok-3-mini": "https://ai4free-test.hf.space/v1/chat/completions",
+  "SciraChat/grok-3-fast": "https://ai4free-test.hf.space/v1/chat/completions",
+  "oivscode/grok-3-beta": "https://ai4free-test.hf.space/v1/chat/completions",
+  "Toolbaz/grok-3-beta": "https://ai4free-test.hf.space/v1/chat/completions",
+  "BLACKBOXAI/Grok 3": "https://ai4free-test.hf.space/v1/chat/completions"
 };
 
 const imageModelRoutes = {

--- a/workers.js
+++ b/workers.js
@@ -1,7 +1,7 @@
 const API_KEY = "ahamaibyprakash25";
 
 const exposedToInternalMap = {
-  "claude-sonnet-4-rproxy": "rproxy/claude-sonnet-4",
+  "claude-sonnet-4": "rproxy/claude-sonnet-4",
   "claude-opus-4": "rproxy/claude-opus-4",
   "grok-3-mini-beta": "HeckAI/x-ai/grok-3-mini-beta",
   "grok-3-mini-fast": "SciraChat/grok-3-mini-fast",


### PR DESCRIPTION
```
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add new Grok models, remove deprecated model endpoints, and simplify Claude model naming.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
New Grok models were added, with `-server-2` variants created for models available from multiple providers (e.g., `grok-3-mini` and `grok-3-beta`). Several old model endpoints and their associated handling logic (including the `handleAshlynn` function) were removed to clean up the configuration. The client-facing name for `claude-sonnet-4-rproxy` was simplified to `claude-sonnet-4` for consistency.
```

---

[Open in Web](https://www.cursor.com/agents?id=bc-41a4e708-0748-4653-918c-1a9313c1440b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-41a4e708-0748-4653-918c-1a9313c1440b)