### PR TITLE
Remove system prompt from models except deepseek-r1

### DIFF
--- a/workers.js
+++ b/workers.js
@@ -238,41 +238,10 @@ async function tryModelRequest(modelId, requestBody, stream, corsHeaders) {
       modifiedBody.messages = requestBody.messages.filter(msg => msg.role !== "system");
       console.log(`🔥 DeepSeek R1 Uncensored Mode: Removed ${requestBody.messages.length - modifiedBody.messages.length} system prompt(s)`);
     } else {
-          // For other models - add screenshot capability system prompt
-    const screenshotSystemPrompt = {
-      role: "system",
-      content: `When users ask for screenshots, generate a URL using this exact format: https://s.wordpress.com/mshots/v1/[ENCODED_URL]?w=1920&h=1080
-
-URL encoding examples:
-- google.com becomes https%3A%2F%2Fgoogle.com
-- github.com becomes https%3A%2F%2Fgithub.com
-- youtube.com becomes https%3A%2F%2Fyoutube.com
-
-If user asks "screenshot of google.com" respond:
-"Here's the screenshot URL: https://s.wordpress.com/mshots/v1/https%3A%2F%2Fgoogle.com?w=1920&h=1080"
-
-If user asks "screenshot of github.com" respond:
-"Here's the screenshot URL: https://s.wordpress.com/mshots/v1/https%3A%2F%2Fgithub.com?w=1920&h=1080"
-
-Always provide the URL when asked for screenshots.`
-    };
-      
-      // Force screenshot capability by merging with existing system prompts
-      const existingSystemIndex = modifiedBody.messages.findIndex(msg => msg.role === "system");
-      
-      if (existingSystemIndex >= 0) {
-        // Merge with existing system prompt
-        const existingContent = modifiedBody.messages[existingSystemIndex].content;
-        modifiedBody.messages[existingSystemIndex].content = `${screenshotSystemPrompt.content}
-
----
-
-${existingContent}`;
-        console.log(`📸 Screenshot capability merged with existing system prompt for ${modelId} (${internal})`);
-      } else {
-        // Add as new system prompt
-        modifiedBody.messages = [screenshotSystemPrompt, ...modifiedBody.messages];
-        console.log(`📸 Screenshot system prompt added to ${modelId} (${internal})`);
+      // For other models - remove all system prompts (no system prompt injection)
+      modifiedBody.messages = requestBody.messages.filter(msg => msg.role !== "system");
+      if (requestBody.messages.length !== modifiedBody.messages.length) {
+        console.log(`🚫 Removed ${requestBody.messages.length - modifiedBody.messages.length} system prompt(s) from ${modelId} (${internal})`);
       }
     }
 


### PR DESCRIPTION
Remove system prompt injection for all models except DeepSeek-R1.

---
<a href="https://cursor.com/background-agent?bcId=bc-0397d8a8-8cba-4eaf-a085-73363381885d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0397d8a8-8cba-4eaf-a085-73363381885d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

