### PR TITLE
Remove system prompt logic from workers.js

### DIFF
--- a/workers.js
+++ b/workers.js
@@ -157,14 +157,7 @@ async function makeModelRequest(modelId, requestBody, stream, corsHeaders) {
     throw new Error(`Model '${modelId}' is not supported or not configured.`);
   }
 
-  // Keep system prompts for ALL models to enable full AI capabilities
-  let modifiedBody = { ...requestBody };
-  modifiedBody.messages = requestBody.messages; // Keep all messages including system prompts
-  
-  const systemPromptCount = requestBody.messages.filter(msg => msg.role === "system").length;
-  if (systemPromptCount > 0) {
-    console.log(`✅ Keeping ${systemPromptCount} system prompt(s) for ${modelId} (${internalModel})`);
-  }
+
 
   let headers = { 
     "Content-Type": "application/json"
@@ -182,7 +175,7 @@ async function makeModelRequest(modelId, requestBody, stream, corsHeaders) {
   const response = await fetch(modelRoutes[internalModel], {
     method: "POST",
     headers: headers,
-    body: JSON.stringify({ ...modifiedBody, model: internalModel })
+    body: JSON.stringify({ ...requestBody, model: internalModel })
   });
 
   // Check if response indicates an error


### PR DESCRIPTION
Remove special system prompt handling logic from `workers.js` to allow the app to directly manage system prompts.

---
<a href="https://cursor.com/background-agent?bcId=bc-40361ce9-43f2-4429-9154-8872bc200716">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40361ce9-43f2-4429-9154-8872bc200716">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

