### PR TITLE
refactor: Remove v0 models and disable automatic web search

### DIFF
--- a/workers.js
+++ b/workers.js
@@ -34,9 +34,7 @@ const exposedToInternalMap = {
   "glm-4.5-air": "zai-org/GLM-4.5-Air",
   "glm-4.5": "zai-org/GLM-4.5",
   
-  // v0.dev Models (2) - Vercel's AI models - Working with streaming ✅
-  "v0-1.0-md": "v0-1.0-md",
-  "v0-1.5-md": "v0-1.5-md",
+  // v0.dev Models (0) - Vercel's AI models - REMOVED
   
   // Airforce API Model (1) - WARNING: Severe rate limit (1 req/min)
   "airforce-gpt-4o-mini": "gpt-4o-mini",
@@ -87,9 +85,7 @@ const modelRoutes = {
   "zai-org/GLM-4.5-Air": "https://gpt-oss-openai-proxy.onrender.com/v1/chat/completions",
   "zai-org/GLM-4.5": "https://gpt-oss-openai-proxy.onrender.com/v1/chat/completions",
   
-  // v0.dev Models (2) - Vercel's AI models
-  "v0-1.0-md": "https://api.v0.dev/v1/chat/completions",
-  "v0-1.5-md": "https://api.v0.dev/v1/chat/completions",
+  // v0.dev Models (0) - Vercel's AI models - REMOVED
   
   // Airforce API (1) - WARNING: 1 request per minute rate limit!
   "gpt-4o-mini": "https://api.airforce/v1/chat/completions",
@@ -255,60 +251,7 @@ const webSearchPatterns = [
 
 // Function to determine if a query needs web search
 function needsWebSearch(messages) {
-  // Get the last few messages for context (not just the last one)
-  const recentMessages = messages.slice(-3); // Check last 3 messages
-  
-  // Combine recent user and assistant messages for context
-  const conversationContext = recentMessages
-    .map(m => {
-      if (m.role === 'user' || m.role === 'assistant') {
-        return typeof m.content === 'string' 
-          ? m.content 
-          : m.content.map(c => c.text || '').join(' ');
-      }
-      return '';
-    })
-    .join(' ');
-  
-  // Get the last user message specifically
-  const lastUserMessage = messages.filter(m => m.role === 'user').pop();
-  if (!lastUserMessage) return false;
-  
-  const lastUserContent = typeof lastUserMessage.content === 'string' 
-    ? lastUserMessage.content 
-    : lastUserMessage.content.map(c => c.text || '').join(' ');
-  
-  // Check if any pattern matches in the recent conversation context
-  for (const pattern of webSearchPatterns) {
-    if (pattern.test(conversationContext)) {
-      return true;
-    }
-  }
-  
-  // Check for follow-up questions that might need web search
-  const followUpPatterns = [
-    /\b(tell me more|more about|what about|how about|and what|also|additionally)\b/i,
-    /\b(update|latest on that|current status|now)\b/i,
-    /\b(any news|any updates|anything new)\b/i
-  ];
-  
-  for (const pattern of followUpPatterns) {
-    if (pattern.test(lastUserContent)) {
-      // Check if previous messages mentioned something that needs current info
-      if (/\b(news|weather|stock|price|event|match|score|release|update)\b/i.test(conversationContext)) {
-        return true;
-      }
-    }
-  }
-  
-  // Additional heuristics for questions
-  if (/^(what|who|where|when|why|how|is|are|does|do|can|could|would|will)\b/i.test(lastUserContent.trim())) {
-    // Check if it's asking about something that might need current information
-    if (/\b(now|today|current|latest|new|2024|2025)\b/i.test(lastUserContent)) {
-      return true;
-    }
-  }
-  
+  // Web search is disabled.
   return false;
 }
 


### PR DESCRIPTION
This commit removes the `v0-1.0-md` and `v0-1.5-md` models from the worker configuration as they were found to be unresponsive.

It also disables the automatic web search feature by modifying the `needsWebSearch` function to always return `false`. This prevents the worker from automatically performing a web search based on the user's query. Web search can still be triggered explicitly.