### PR TITLE
Fix: Disallow tool calls from client

### DIFF
--- a/workers.js
+++ b/workers.js
@@ -650,8 +650,21 @@ async function handleChat(request, corsHeaders, env) {
       return new Response(JSON.stringify({ error: `Model '${exposedModel}' is not supported.` }), { status: 400, headers: corsHeaders });
     }
 
-    // Directly call the model without tool logic
-    const payload = { ...requestBody, model: internalModel, messages, stream };
+    // Sanitize the payload to remove any tool-related parameters
+    const payload = {
+        model: internalModel,
+        messages: messages,
+        stream: stream,
+        temperature: requestBody.temperature,
+        max_tokens: requestBody.max_tokens,
+        top_p: requestBody.top_p,
+        seed: requestBody.seed,
+        stop: requestBody.stop
+    };
+
+    // Remove undefined properties to avoid sending them in the request
+    Object.keys(payload).forEach(key => payload[key] === undefined && delete payload[key]);
+
     const finalResponse = await executeModelRequest(internalModel, payload, stream);
 
     if (stream) {


### PR DESCRIPTION
The `handleChat` function was previously forwarding the entire request body from the client to the model API. This allowed clients to pass `tools` and `tool_choice` parameters, causing the AI to attempt tool calls even though the web search tool was meant to be disabled.

This patch fixes the issue by sanitizing the payload. The `handleChat` function now explicitly constructs the payload object, including only the allowed, safe parameters and excluding any tool-related fields. This prevents the model from receiving tool-calling instructions from the client.