### PR TITLE
Handle missing messages in chat requests

### DIFF
--- a/workers.js
+++ b/workers.js
@@ -1142,7 +1142,14 @@ async function handleChat(request, corsHeaders, env) {
     const exposedModel = requestBody.model || "qwen-235b";
     const requestedStream = requestBody.stream === true;
     let tools = requestBody.tools || [];
-    let messages = requestBody.messages;
+    let messages = requestBody.messages || [];
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return new Response(
+        JSON.stringify({ error: "The 'messages' array is required." }),
+        { status: 400, headers: { "Content-Type": "application/json", ...corsHeaders } }
+      );
+    }
 
     const internalModel = exposedToInternalMap[exposedModel];
     if (!internalModel) {


### PR DESCRIPTION
## Summary
- guard against requests lacking a `messages` array to prevent crashes
- return an explicit 400 error when `messages` is missing or empty

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b59cbd52cc832681cd574b443a9124